### PR TITLE
Fixed issues with being able to use saml login

### DIFF
--- a/app/bundles/UserBundle/Entity/IdEntry.php
+++ b/app/bundles/UserBundle/Entity/IdEntry.php
@@ -3,6 +3,7 @@
 namespace Mautic\UserBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 
 /**
  * @ORM\Entity()

--- a/app/config/security.php
+++ b/app/config/security.php
@@ -88,8 +88,18 @@ $container->loadFromExtension(
                 'mautic_plugin_auth' => true,
                 'stateless'          => true
             ),
+            'saml_login'                => array(
+                'pattern'   => '^/saml/login$',
+                'anonymous' => true,
+                'context'   => 'mautic'
+            ),
+            'saml_discovery'                => array(
+                'pattern'   => '^/saml/discovery$',
+                'anonymous' => true,
+                'context'   => 'mautic'
+            ),
             'saml' => array(
-                'pattern'     => "^/saml/",
+                'pattern'     => '^/saml/',
                 'light_saml_sp'     => array(
                     'user_creator'      => 'mautic.security.saml.user_creator',
                     'login_path'        => '/saml/login',


### PR DESCRIPTION
The public pages for /saml had to be declared as anonymous in order for the firewall to allow access without an authenticated session.
