### PR TITLE
correcting pagination settings. Now showing first page item and last …

### DIFF
--- a/app/bundles/PluginBundle/Form/Type/FeatureSettingsType.php
+++ b/app/bundles/PluginBundle/Form/Type/FeatureSettingsType.php
@@ -73,10 +73,10 @@ class FeatureSettingsType extends AbstractType
             $session = $this->session;
             $limit   = $session->get('mautic.lead.limit', $this->coreParametersHelper->getParameter('default_pagelimit'));
             $page    = $session->get('mautic.plugin.lead.page', 1);
-            $start   = $session->get('mautic.plugin.lead.start', 1);
+            $start   = $session->get('mautic.plugin.lead.start', 0);
 
             $companyPage  = $session->get('mautic.plugin.company.lead.page', 1);
-            $companyStart = $session->get('mautic.plugin.company.start', 1);
+            $companyStart = $session->get('mautic.plugin.company.start', 0);
 
             $settings = [
                 'silence_exceptions' => false,
@@ -148,7 +148,7 @@ class FeatureSettingsType extends AbstractType
                     'page'                 => $page,
                     'limit'                => $limit,
                     'start'                => $start,
-                    'fixedPageNum'         => round($totalFields / $limit),
+                    'fixedPageNum'         => ceil($totalFields / $limit),
                 ]
             );
             if (!empty($integrationCompanyFields)) {
@@ -171,7 +171,7 @@ class FeatureSettingsType extends AbstractType
                         'page'                       => $companyPage,
                         'limit'                      => $limit,
                         'start'                      => $companyStart,
-                        'fixedPageNum'               => round($totalCompanyFields / $limit),
+                        'fixedPageNum'               => ceil($totalCompanyFields / $limit),
                     ]
                 );
             }


### PR DESCRIPTION
…page.

Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? |n 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

**Note that all new features should have a related user and/or developer documentation PR in their respective repositories.** 

### Required
#### Description:
Correcting a problem with contact and company settings.
First item of each page didn't show due to wrong paginations settings.
Last page didn't show either due to use of "round" instead of "ceil".

#### Steps to test this PR:
1. Reload pluging company or contact fields
2. 

### As applicable
#### Steps to reproduce the bug:
1. Load pluging company or contact fields
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 